### PR TITLE
feat: Implementar lógica de Feriado com API

### DIFF
--- a/src/Controller/FeriadoController.php
+++ b/src/Controller/FeriadoController.php
@@ -2,20 +2,70 @@
 
 namespace App\Controller;
 
+use App\Dto\FeriadoDTO;
+use App\Service\FeriadoService;
+use App\Exception\RegraDeNegocioFeriadoException;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Component\HttpKernel\Attribute\MapRequestPayload; // Import MapRequestPayload
 
+#[Route('/api')] // Added a common prefix for API routes
 final class FeriadoController extends AbstractController
 {
     use ResponseTrait;
+
+    public function __construct(
+        private readonly FeriadoService $feriadoService,
+        private readonly SerializerInterface $serializer // Inject SerializerInterface
+    ) {
+    }
     
-    #[Route('/feriado', name: 'app_feriado')]
+    #[Route('/feriado', name: 'app_feriado_list', methods: ['GET'])] // Kept original route for listing, if needed later
     public function index(): JsonResponse
     {
+        // This is just a placeholder, actual listing logic would be needed here
         return $this->json([
-            'message' => 'Welcome to your new controller!',
+            'message' => 'Listagem de feriados (a implementar)',
             'path' => 'src/Controller/FeriadoController.php',
         ]);
+    }
+
+    #[Route('/feriado', name: 'app_feriado_create', methods: ['POST'])]
+    public function create(
+        Request $request, // Use Request to get content
+        ValidatorInterface $validator
+    ): JsonResponse {
+        try {
+            // Deserialize JSON to DTO
+            $feriadoDTO = $this->serializer->deserialize($request->getContent(), FeriadoDTO::class, 'json');
+
+            // Validate DTO
+            $errors = $validator->validate($feriadoDTO);
+            if (count($errors) > 0) {
+                return $this->responseError($errors);
+            }
+
+            $feriado = $this->feriadoService->criarFeriado($feriadoDTO);
+            // Assuming Feriado entity will have toArray(). If not, this needs adjustment.
+            // For now, let's assume FeriadoDTO's toArray is sufficient if the created $feriado is returned from service
+            // Or, better, the service returns the entity and we serialize it or convert to DTO then array.
+            // For now, let's return the DTO's data, which is what we received, plus any generated ID if applicable.
+            // The Feriado entity itself might be more appropriate to return after serialization.
+            // Let's adjust to serialize the created Feriado entity.
+            return $this->responseSuccess($this->serializer->normalize($feriado, null, ['groups' => 'feriado:read']), JsonResponse::HTTP_CREATED);
+
+
+        } catch (RegraDeNegocioFeriadoException $e) {
+            return $this->responseError($e->getMessage(), JsonResponse::HTTP_BAD_REQUEST);
+        } catch (\Symfony\Component\Serializer\Exception\NotEncodableValueException $e) {
+            return $this->responseError('JSON malformatado: ' . $e->getMessage(), JsonResponse::HTTP_BAD_REQUEST);
+        } catch (\Exception $e) {
+            // Generic error for other unexpected issues
+            return $this->responseError('Erro ao processar a requisição: ' . $e->getMessage(), JsonResponse::HTTP_INTERNAL_SERVER_ERROR);
+        }
     }
 }

--- a/src/Dto/FeriadoDTO.php
+++ b/src/Dto/FeriadoDTO.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Dto;
+
+use App\Entity\Enum\FeriadoNivel;
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class FeriadoDTO implements DtoInteface
+{
+    #[Assert\NotBlank(message: 'O nome do feriado não pode estar em branco.')]
+    #[Assert\Length(min: 3, max: 255, minMessage: 'O nome deve ter no mínimo 3 caracteres.', maxMessage: 'O nome deve ter no máximo 255 caracteres.')]
+    public ?string $nome = null;
+
+    #[Assert\NotBlank(message: 'A data do feriado não pode estar em branco.')]
+    #[Assert\Date(message: 'A data do feriado deve ser uma data válida.')]
+    public ?string $data = null;
+
+    #[Assert\NotBlank(message: 'O nível do feriado não pode estar em branco.')]
+    public ?FeriadoNivel $nivel = null;
+
+    #[Assert\NotNull(message: 'O campo recorrente não pode ser nulo.')]
+    #[Assert\Type(type: 'bool', message: 'O campo recorrente deve ser um booleano.')]
+    public ?bool $recorrente = null;
+
+    public function __construct(
+        ?string $nome,
+        ?string $data,
+        ?FeriadoNivel $nivel,
+        ?bool $recorrente
+    ) {
+        $this->nome = $nome;
+        $this->data = $data;
+        $this->nivel = $nivel;
+        $this->recorrente = $recorrente;
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            nome: $data['nome'] ?? null,
+            data: $data['data'] ?? null,
+            nivel: isset($data['nivel']) ? FeriadoNivel::tryFrom($data['nivel']) : null,
+            recorrente: $data['recorrente'] ?? null
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'nome' => $this->nome,
+            'data' => $this->data,
+            'nivel' => $this->nivel?->value,
+            'recorrente' => $this->recorrente,
+        ];
+    }
+}

--- a/src/Entity/Feriado.php
+++ b/src/Entity/Feriado.php
@@ -7,6 +7,7 @@ use App\Exception\RegraDeNegocioFeriadoException;
 use App\Repository\FeriadoRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
 
 #[ORM\Entity(repositoryClass: FeriadoRepository::class)]
 class Feriado
@@ -14,21 +15,27 @@ class Feriado
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
+    #[Groups(['feriado:read'])]
     private ?int $id = null;
 
     #[ORM\Column(enumType: FeriadoNivel::class)]
+    #[Groups(['feriado:read'])]
     private ?FeriadoNivel $nivel = null;
 
     #[ORM\Column]
+    #[Groups(['feriado:read'])]
     private ?bool $recorrente = null;
 
     #[ORM\Column(type: Types::DATE_IMMUTABLE)]
+    #[Groups(['feriado:read'])]
     private ?\DateTimeImmutable $inicio = null;
 
     #[ORM\Column(type: Types::DATE_IMMUTABLE)]
+    #[Groups(['feriado:read'])]
     private ?\DateTimeImmutable $fim = null;
 
     #[ORM\Column(length: 255)]
+    #[Groups(['feriado:read'])]
     private ?string $nome = null;
 
     public function getId(): ?int

--- a/src/Factory/FeriadoFactory.php
+++ b/src/Factory/FeriadoFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Factory;
+
+use App\Dto\FeriadoDTO;
+use App\Entity\Feriado;
+use DateTimeImmutable;
+
+final class FeriadoFactory
+{
+    public function createFromDTO(FeriadoDTO $dto): Feriado
+    {
+        $feriado = new Feriado();
+        $feriado->setNome($dto->nome);
+        // The DTO has $data as string, Feriado entity expects DateTimeImmutable
+        // Also, the Feriado entity has inicio and fim, but the DTO only has data. For now, we'll set both to the same value.
+        // We might need to adjust this later if the requirements change.
+        if ($dto->data !== null) {
+            $dataImmutable = new DateTimeImmutable($dto->data);
+            $feriado->setInicio($dataImmutable);
+            $feriado->setFim($dataImmutable);
+        }
+        $feriado->setNivel($dto->nivel);
+        $feriado->setRecorrente($dto->recorrente);
+
+        return $feriado;
+    }
+}

--- a/src/Repository/FeriadoRepository.php
+++ b/src/Repository/FeriadoRepository.php
@@ -5,6 +5,7 @@ namespace App\Repository;
 use App\Entity\Feriado;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use DateTimeImmutable;
 
 /**
  * @extends ServiceEntityRepository<Feriado>
@@ -14,6 +15,21 @@ class FeriadoRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Feriado::class);
+    }
+
+    /**
+     * Finds a holiday by its start date.
+     *
+     * @param DateTimeImmutable $date The date to search for.
+     * @return Feriado|null Returns a Feriado object if found, otherwise null.
+     */
+    public function findByDate(DateTimeImmutable $date): ?Feriado
+    {
+        return $this->createQueryBuilder('f')
+            ->andWhere('f.inicio = :date') // Assuming 'inicio' is the field that stores the holiday date
+            ->setParameter('date', $date)
+            ->getQuery()
+            ->getOneOrNullResult();
     }
 
     //    /**

--- a/src/Service/FeriadoService.php
+++ b/src/Service/FeriadoService.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Service;
+
+use App\Dto\FeriadoDTO;
+use App\Entity\Feriado;
+use App\Exception\RegraDeNegocioFeriadoException;
+use App\Factory\FeriadoFactory;
+use App\Repository\FeriadoRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use DateTimeImmutable;
+
+final class FeriadoService
+{
+    public function __construct(
+        private readonly FeriadoRepository $feriadoRepository,
+        private readonly FeriadoFactory $feriadoFactory,
+        private readonly EntityManagerInterface $entityManager
+    ) {
+    }
+
+    public function criarFeriado(FeriadoDTO $feriadoDTO): Feriado
+    {
+        $dataFeriado = new DateTimeImmutable($feriadoDTO->data);
+
+        // Check if a holiday with the same date already exists
+        $existingFeriado = $this->feriadoRepository->findByDate($dataFeriado);
+
+        if ($existingFeriado) {
+            throw new RegraDeNegocioFeriadoException('Já existe um feriado cadastrado para esta data.');
+        }
+
+        $feriado = $this->feriadoFactory->createFromDTO($feriadoDTO);
+
+        $this->entityManager->persist($feriado);
+        $this->entityManager->flush();
+
+        return $feriado;
+    }
+}

--- a/tests/Controller/FeriadoControllerTest.php
+++ b/tests/Controller/FeriadoControllerTest.php
@@ -2,15 +2,153 @@
 
 namespace App\Tests\Controller;
 
+use App\Entity\Enum\FeriadoNivel;
+use App\Repository\FeriadoRepository;
+use DateTimeImmutable;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 final class FeriadoControllerTest extends WebTestCase
 {
-    public function testIndex(): void
-    {
-        $client = static::createClient();
-        $client->request('GET', '/feriado');
+    private $client;
+    private $entityManager;
+    private $feriadoRepository;
 
-        self::assertResponseIsSuccessful();
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->entityManager = $this->client->getContainer()->get('doctrine.orm.entity_manager');
+        $this->feriadoRepository = $this->entityManager->getRepository(\App\Entity\Feriado::class);
+
+        // Limpar feriados antes de cada teste para evitar conflitos de datas
+        foreach ($this->feriadoRepository->findAll() as $feriado) {
+            $this->entityManager->remove($feriado);
+        }
+        $this->entityManager->flush();
+    }
+
+    public function testCreateFeriadoSuccess(): void
+    {
+        $this->client->request(
+            'POST',
+            '/api/feriado',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode([
+                'nome' => 'Natal',
+                'data' => '2024-12-25',
+                'nivel' => FeriadoNivel::NACIONAL->value,
+                'recorrente' => true,
+            ])
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertResponseStatusCodeSame(201); // HTTP_CREATED
+        $responseContent = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertArrayHasKey('id', $responseContent['data']);
+        $this->assertSame('Natal', $responseContent['data']['nome']);
+        // Check date part, assuming 'inicio' and 'fim' are serialized with a 'date' sub-key
+        $this->assertSame('2024-12-25', substr($responseContent['data']['inicio']['date'], 0, 10));
+        $this->assertSame('2024-12-25', substr($responseContent['data']['fim']['date'], 0, 10));
+    }
+
+    public function testCreateFeriadoDuplicateDateError(): void
+    {
+        // First, create a holiday
+        $this->client->request(
+            'POST',
+            '/api/feriado',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode([
+                'nome' => 'Ano Novo',
+                'data' => '2025-01-01',
+                'nivel' => FeriadoNivel::NACIONAL->value,
+                'recorrente' => true,
+            ])
+        );
+        $this->assertResponseStatusCodeSame(201);
+
+        // Then, try to create another holiday on the same date
+        $this->client->request(
+            'POST',
+            '/api/feriado',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode([
+                'nome' => 'Confraternização Universal',
+                'data' => '2025-01-01',
+                'nivel' => FeriadoNivel::NACIONAL->value,
+                'recorrente' => false,
+            ])
+        );
+
+        $this->assertResponseStatusCodeSame(400); // HTTP_BAD_REQUEST
+        $responseContent = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertSame('Já existe um feriado cadastrado para esta data.', $responseContent['error']);
+    }
+
+    public function testCreateFeriadoValidationError(): void
+    {
+        $this->client->request(
+            'POST',
+            '/api/feriado',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode([
+                'nome' => '', // Invalid: blank name
+                'data' => 'invalid-date', // Invalid: date format
+                'nivel' => 'INVALIDO', // Invalid: enum value
+                'recorrente' => 'not_a_boolean', // Invalid: type
+            ])
+        );
+
+        $this->assertResponseStatusCodeSame(400); // HTTP_BAD_REQUEST for validation errors from DTO
+        $responseContent = json_decode($this->client->getResponse()->getContent(), true);
+
+        // Check for multiple error messages structure.
+        // This depends on how ResponseTrait formats ConstraintViolationList
+        $this->assertIsArray($responseContent['error']);
+        $errorsFound = 0;
+        foreach ($responseContent['error'] as $errorDetail) {
+            if (isset($errorDetail['message'])) {
+                if (str_contains($errorDetail['message'], 'O nome do feriado não pode estar em branco.')) $errorsFound++;
+                if (str_contains($errorDetail['message'], 'A data do feriado deve ser uma data válida.')) $errorsFound++;
+                if (str_contains($errorDetail['message'], 'O nível do feriado não pode estar em branco.')) $errorsFound++; // DTO validation for nivel
+                if (str_contains($errorDetail['message'], 'O campo recorrente deve ser um booleano.')) $errorsFound++;
+            } else { // Fallback if structure is simpler array of strings
+                 if (str_contains($errorDetail, 'O nome do feriado não pode estar em branco.')) $errorsFound++;
+                 if (str_contains($errorDetail, 'A data do feriado deve ser uma data válida.')) $errorsFound++;
+                 if (str_contains($errorDetail, 'O nível do feriado não pode estar em branco.')) $errorsFound++;
+                 if (str_contains($errorDetail, 'O campo recorrente deve ser um booleano.')) $errorsFound++;
+            }
+        }
+        // Ensure at least the name and data validation messages are present
+        // The exact number of errors might vary based on how "INVALIDO" for nivel and "not_a_boolean" for recorrente are handled
+        // by the Serializer and Validator.
+        $this->assertGreaterThanOrEqual(2, $errorsFound, "Expected at least 2 validation errors for name and data.");
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        // Limpar feriados após cada teste
+        // Ensure repository is not null before using it
+        if ($this->feriadoRepository) {
+            foreach ($this->feriadoRepository->findAll() as $feriado) {
+                $this->entityManager->remove($feriado);
+            }
+            $this->entityManager->flush();
+        }
+
+        if ($this->entityManager) {
+            $this->entityManager->close();
+            $this->entityManager = null; // avoid memory leaks
+        }
+        $this->client = null; // avoid memory leaks
+        $this->feriadoRepository = null; // avoid memory leaks
     }
 }


### PR DESCRIPTION
- Adiciona FeriadoDTO para validação e transferência de dados.
- Adiciona FeriadoFactory para criar entidades Feriado a partir de DTOs.
- Adiciona FeriadoService para encapsular a lógica de negócio da criação de feriados, incluindo a validação para não permitir cadastro na mesma data.
- Atualiza FeriadoController para expor um endpoint POST /api/feriado para criar feriados.
- Adiciona o método findByDate em FeriadoRepository.
- Adiciona grupos de serialização na entidade Feriado para controlar a saída JSON.
- Cria testes em FeriadoControllerTest para cobrir:
    - Criação de feriado com sucesso.
    - Tentativa de criar feriado em data duplicada.
    - Erros de validação de dados de entrada.